### PR TITLE
allow management of allowed and denied users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,7 @@ incron_system_tables: []
 
 incron_user_tables_dir: "/var/spool/incron/"
 incron_user_tables: []
+
+incron_manage_allowdenylist: false
+incron_users_allowed: []
+incron_users_denied: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,3 +50,29 @@
   when: incron_user_tables is defined
   notify:
     - restart incron
+
+- name: Configure allow list
+  copy:
+    dest: /etc/incron.allow
+    owner: root
+    group: incron
+    mode: 0640
+    content: "{{ incron_users_allowed | join('\n') }}{{ add_nl }}"
+  when: incron_manage_allowdenylist
+  vars:
+    add_nl: "{{ (incron_users_allowed|length == 0) | ternary('','\n') }}"
+  notify:
+    - restart incron
+
+- name: Configure deny list
+  copy:
+    dest: /etc/incron.deny
+    owner: root
+    group: incron
+    mode: 0640
+    content: "{{ incron_users_denied | join('\n') }}{{ add_nl }}"
+  when: incron_manage_allowdenylist
+  vars:
+    add_nl: "{{ (incron_users_denied|length == 0) | ternary('','\n') }}"
+  notify:
+    - restart incron


### PR DESCRIPTION
On, at keast,  debian systems the incron package creates both `incron.allow` and `incron.deny` empty files. It prevents any user to use incron.
This PR allows the management of those files with defaults keeping the original behavior.